### PR TITLE
Add compatibility for python3

### DIFF
--- a/loader.py
+++ b/loader.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import re
 import codecs
@@ -61,9 +62,9 @@ def word_mapping(sentences, lower):
     dico = create_dico(words)
     dico['<UNK>'] = 10000000
     word_to_id, id_to_word = create_mapping(dico)
-    print "Found %i unique words (%i in total)" % (
+    print("Found %i unique words (%i in total)" % (
         len(dico), sum(len(x) for x in words)
-    )
+    ))
     return dico, word_to_id, id_to_word
 
 
@@ -74,7 +75,7 @@ def char_mapping(sentences):
     chars = ["".join([w[0] for w in s]) for s in sentences]
     dico = create_dico(chars)
     char_to_id, id_to_char = create_mapping(dico)
-    print "Found %i unique characters" % len(dico)
+    print("Found %i unique characters" % len(dico))
     return dico, char_to_id, id_to_char
 
 
@@ -85,7 +86,7 @@ def tag_mapping(sentences):
     tags = [[word[-1] for word in s] for s in sentences]
     dico = create_dico(tags)
     tag_to_id, id_to_tag = create_mapping(dico)
-    print "Found %i unique named entity tags" % len(dico)
+    print("Found %i unique named entity tags" % len(dico))
     return dico, tag_to_id, id_to_tag
 
 
@@ -162,7 +163,7 @@ def augment_with_pretrained(dictionary, ext_emb_path, words):
     to the dictionary, otherwise, we only add the words that are given by
     `words` (typically the words in the development and test sets.)
     """
-    print 'Loading pretrained embeddings from %s...' % ext_emb_path
+    print('Loading pretrained embeddings from %s...' % ext_emb_path)
     assert os.path.isfile(ext_emb_path)
 
     # Load pretrained embeddings from file

--- a/model.py
+++ b/model.py
@@ -1,6 +1,11 @@
 from __future__ import print_function
 import logging
-import cPickle
+
+try:
+    import cPickle
+except ImportError:
+    import pickle as cPickle
+
 import os
 import re
 import numpy as np


### PR DESCRIPTION
This PR aims to make the code compatible with Python3 when running with an input file.

There were two problems that needed fixing
* cPickle which has been replaced with pickle
* print statement in loaders